### PR TITLE
fix: quickstart server url, use latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ This quickstart example requires the following tools to work:
 
 2. Run `docker compose up` to start the Hatchet instance. This will take a few minutes, as the docker compose services set up the database and generate the required certificates to connect to the Hatchet instance. You can also run `docker compose up -d` to start this in the background. Once you start to see output from the `engine` and `api` services, you can move on to the next step.
 
-3. You should be able to navigate to [localhost:8020](http://localhost:8020) and use the following credentials to log in:
+3. You should be able to navigate to [localhost:8080](http://localhost:8080) and use the following credentials to log in:
 
-    ```
-    Email: admin@example.com
-    Password: Admin123!!
-    ```
+   ```
+   Email: admin@example.com
+   Password: Admin123!!
+   ```
 
 4. Create a token. You can do this from the dashboard or from the CLI:
 
@@ -34,14 +34,14 @@ echo "HATCHET_CLIENT_TOKEN=$HATCHET_CLIENT_TOKEN" > .env
 ```
 
 **From the dashboard:**
-    
+
 - Navigate to the [token page](https://app.dev.hatchet-tools.com/tenant-settings/api-tokens) and create a token.
 - Click the copy to clipboard button and paste into a new file called `.env` in the root of this repository.
 
 5. Start the server and worker:
 
 ```
-go run ./cmd/server & go run ./cmd/worker
+trap "pkill -P $$" EXIT; go run ./cmd/server & go run ./cmd/worker
 ```
 
 6. Run `curl http://localhost:1323/test` to test the endpoint.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:16
     command: postgres -c 'max_connections=200'
     restart: always
     hostname: "postgres-go-quickstart"
@@ -37,29 +37,26 @@ services:
       timeout: 10s
       retries: 5
   migration:
-    build:
-      context: .github/docker
-      dockerfile: migrate.dockerfile
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
     environment:
       DATABASE_URL: "postgres://hatchet:hatchet@postgres-go-quickstart:5432/hatchet"
     depends_on:
       postgres:
         condition: service_healthy
   setup-config:
-    build:
-      context: .github/docker
-      dockerfile: admin.dockerfile
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
     command: /hatchet/hatchet-admin quickstart --cert-dir /hatchet/certs --generated-config-dir /hatchet/config --overwrite=false
     environment:
       DATABASE_URL: "postgres://hatchet:hatchet@postgres-go-quickstart:5432/hatchet"
       DATABASE_POSTGRES_PORT: "5432"
       DATABASE_POSTGRES_HOST: "postgres-go-quickstart"
       SERVER_TASKQUEUE_RABBITMQ_URL: amqp://user:password@rabbitmq-go-quickstart:5672/
-      SERVER_AUTH_COOKIE_DOMAIN: localhost:8020
+      SERVER_AUTH_COOKIE_DOMAIN: localhost:8080
       SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
       SERVER_GRPC_BROADCAST_ADDRESS: "127.0.0.1:7077"
       SERVER_GRPC_PORT: "7077"
       SERVER_GRPC_INSECURE: "true"
+      SERVER_URL: "http://localhost:8080"
     volumes:
       - ./certs:/hatchet/certs
       - hatchet_quickstart_config:/hatchet/config
@@ -71,9 +68,7 @@ services:
       postgres:
         condition: service_healthy
   hatchet-engine:
-    build:
-      context: .github/docker
-      dockerfile: engine.dockerfile
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest
     command: /hatchet/hatchet-engine --config /hatchet/config
     restart: on-failure
     depends_on:
@@ -92,14 +87,12 @@ services:
     volumes:
       - ./certs:/hatchet/certs
       - hatchet_quickstart_config:/hatchet/config
-  hatchet-api:
-    build:
-      context: .github/docker
-      dockerfile: api.dockerfile
-    command: /hatchet/hatchet-api --config /hatchet/config
+  hatchet-dashboard:
+    image: ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:latest
+    command: sh ./entrypoint.sh --config /hatchet/config
     restart: on-failure
     ports:
-      - "8088:8080"
+      - "8080:80"
     depends_on:
       setup-config:
         condition: service_completed_successfully
@@ -110,18 +103,6 @@ services:
     volumes:
       - ./certs:/hatchet/certs
       - hatchet_quickstart_config:/hatchet/config
-  hatchet-frontend:
-    build:
-      context: .github/docker
-      dockerfile: frontend.dockerfile
-    ports:
-      - "9099:80"
-  caddy:
-    image: caddy:2.7.6-alpine
-    ports:
-      - 8020:80
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
 
 volumes:
   hatchet_quickstart_postgres_data:


### PR DESCRIPTION
- Sets the `SERVER_URL` correctly so that workers can connect to REST endpoints. 
- Bumps the version of Hatchet to `latest` 
- Removes the need for caddy + the API by using the `hatchet-dashboard` image. 